### PR TITLE
Add support for Soehnle Systo Monitor Connect 400

### DIFF
--- a/src/devices/device.rs
+++ b/src/devices/device.rs
@@ -22,6 +22,8 @@ pub fn make_device(device_info: DeviceInfo) -> Option<Box<dyn Device>> {
             Some(Box::new(contour::ElitePlus::new(device_info)))
         } else if name.contains("Shape200") {
             Some(Box::new(soehnle::Shape200::new(device_info)))
+        } else if name.contains("Systo MC 400") {
+            Some(Box::new(soehnle::SystoMC400::new(device_info)))
         } else {
             None
         }

--- a/src/store/measurement.rs
+++ b/src/store/measurement.rs
@@ -17,6 +17,9 @@ pub enum Value {
     FatPercent(f64),
     Glucose(i32),
     Meal(MealIndicator),
+    BloodPressureSystolic(i32),
+    BloodPressureDiastolic(i32),
+    HeartRate(i32),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The blood pressure monitor seems to work according to the Blood Pressure Service spec: https://www.bluetooth.com/specifications/specs/blood-pressure-service-1-1-1/

Testing results:

```
2022-08-06 14:58:59.542 INFO wagapi: Found device Systo MC 400, connecting
2022-08-06 14:59:04.805 INFO wagapi: Getting data from Systo MC 400
2022-08-06 14:59:04.805 DEBUG wagapi::devices::soehnle: Getting measurements characteristic
2022-08-06 14:59:04.830 DEBUG wagapi::devices::soehnle: Got: CharacteristicId { object_path: Path("/org/bluez/hci0/dev_FF_4E_BC_F7_85_A6/service0009/char000a\0") }
2022-08-06 14:59:04.830 DEBUG wagapi::devices::soehnle: Listening for events
2022-08-06 14:59:05.598 DEBUG wagapi::devices::soehnle: Waiting for events
2022-08-06 14:59:06.183 DEBUG wagapi::devices::soehnle: Received characteristic event: [30, 128, 0, 75, 0, 93, 0, 230, 7, 8, 4, 13, 49, 0, 80, 0, 0, 0, 0]
2022-08-06 14:59:06.476 DEBUG wagapi::devices::soehnle: Received characteristic event: [30, 123, 0, 72, 0, 89, 0, 230, 7, 8, 4, 14, 11, 0, 83, 0, 0, 0, 0]
2022-08-06 14:59:06.768 DEBUG wagapi::devices::soehnle: Received characteristic event: [30, 112, 0, 68, 0, 83, 0, 230, 7, 8, 4, 15, 53, 0, 86, 0, 0, 0, 0]
2022-08-06 14:59:06.914 DEBUG wagapi::devices::soehnle: Received characteristic event: [30, 111, 0, 69, 0, 83, 0, 230, 7, 8, 4, 15, 55, 0, 81, 0, 0, 0, 0]
2022-08-06 14:59:11.916 DEBUG wagapi::devices::soehnle: Processed all events, produced 4 records
2022-08-06 14:59:11.916 INFO wagapi: Fetched 4 records
2022-08-06 14:59:11.916 DEBUG wagapi: Last 5 records loaded
2022-08-06 14:59:11.916 DEBUG wagapi: Record { timestamp: 2022-08-04T15:55:00, values: [BloodPressureSystolic(111), BloodPressureDiastolic(69), HeartRate(81)] }
2022-08-06 14:59:11.916 DEBUG wagapi: Record { timestamp: 2022-08-04T15:53:00, values: [BloodPressureSystolic(112), BloodPressureDiastolic(68), HeartRate(86)] }
2022-08-06 14:59:11.916 DEBUG wagapi: Record { timestamp: 2022-08-04T14:11:00, values: [BloodPressureSystolic(123), BloodPressureDiastolic(72), HeartRate(83)] }
2022-08-06 14:59:11.916 DEBUG wagapi: Record { timestamp: 2022-08-04T13:49:00, values: [BloodPressureSystolic(128), BloodPressureDiastolic(75), HeartRate(80)] }
2022-08-06 14:59:11.916 INFO wagapi: Ignoring device Systo MC 400 until 2022-08-06 14:04:11.916787509 UTC
2022-08-06 14:59:11.916 INFO wagapi: Disconnecting
```